### PR TITLE
Updated small bug and added small workflow sizes

### DIFF
--- a/bwa/README.md
+++ b/bwa/README.md
@@ -43,6 +43,14 @@ Workflow ~2 mins on 20 workers:
 ```
 ./fastq_generate.pl 100000 1000 > ref.fastq
 ./fastq_generate.pl 10000 1000 ref.fastq > query.fastq
+./make_bwa_workflow --ref ref.fastq --query query.fastq --num_seq 1000 > bwa.mf
 ```
 
+Workflow ~6 mins on 20 workers:
+
+```
+./fastq_generate.pl 100000 1000 > ref.fastq
+./fastq_generate.pl 1000000 100 ref.fastq > query.fastq
+./make_bwa_workflow --ref ref.fastq --query query.fastq --num_seq 1000 --algo backtrack > bwa.mf
+```
 

--- a/bwa/make_bwa_workflow
+++ b/bwa/make_bwa_workflow
@@ -316,7 +316,7 @@ def write_makeflow(destination, configuration, num_reads_per_split, fastq_name, 
 					if bwa_args["samse"]:
 						se_a = ' '.join(bwa_args["samse"])
 
-					makeflow.write("\n\n {0} {1} : bwa {2} {3} {4}".format(output, error, index, query1, sai1))
+					makeflow.write("\n\n{0} {1} : bwa {2} {3} {4}".format(output, error, index, query1, sai1))
 					makeflow.write("\n\t./bwa samse {0} {1} {2} {3} > {4} 2> {5}".format(se_a, ref, sai1, query1, output, error))
 
 			else:


### PR DESCRIPTION
Removed space that caused issue with BWA backtrack. Added smaller examples. BWA was having issues if the reference was to large. I can add longer tests, it just requires larger query files.