### PR TITLE
Moved to tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ files in each directory:
 - BLAST, SSAHA, and BWA contain complete instructions for downloading software,
 generating sample data, and creating and running complete workflows from scratch.
 
+- It should be noted that the sample data that is generated in these is complelely
+random and has no value other than for showing these workflows in action. As a result
+some generated behavior may appear to cause issues when programs expect some format 
+or quality guarantee.
+
 - The other examples are static snapshots of workflows for display
 or analysis, but do not contain the actual applications necessary to run them.
 

--- a/blast/README.md
+++ b/blast/README.md
@@ -83,18 +83,10 @@ adjusting the number of contigs and the second adjusting the length of these con
 
 The provided values produces a workflow that runs in ~5 minutes on a local single core machine.
 
-To produce a workflow that runs ~20 minutes on a 20 single core machines:
-```
-./fasta_generator 30000 2000 > test.fasta
-./makeflow_blast -d nt -i test.fasta -p blastn --num_seq 100 --makeflow blast_test.mf
-```
-
-To produce a workflow that runs ~30 minutes on a 75 single core machines:
-```
-./fasta_generator 100000 2000 > test.fasta
-./makeflow_blast -d nt -i test.fasta -p blastn --num_seq 1000 --makeflow blast_test.mf
-```
-
-
-
+<table cellpadding=20>
+<tr><td>Workflow Size<td>Reference Size<td>Query Size(Number x Length)<td>Number of seq per split<td> Approx Time with Machine
+<tr><td>Small<td>NT (Fixed 565MB)<td>200x1000 (198K)<td>5 <td> ~5 min : 1 machine
+<tr><td>Medium<td><td>NT (Fixed 565MB)<td>30000x2000 (58M)<td>100 <td> ~20 min : 20 machines
+<tr><td>Large<td><td>NT (Fixed 565MB)<td>100000x2000 (193M)<td>1000 <td> ~30 min : 75 machines
+</table>
 

--- a/blast/README.md
+++ b/blast/README.md
@@ -86,7 +86,7 @@ The provided values produces a workflow that runs in ~5 minutes on a local singl
 <table cellpadding=20>
 <tr><td>Workflow Size<td>Reference Size<td>Query Size(Number x Length)<td>Number of seq per split<td> Approx Time with Machine
 <tr><td>Small<td>NT (Fixed 565MB)<td>200x1000 (198K)<td>5 <td> ~5 min : 1 machine
-<tr><td>Medium<td><td>NT (Fixed 565MB)<td>30000x2000 (58M)<td>100 <td> ~20 min : 20 machines
-<tr><td>Large<td><td>NT (Fixed 565MB)<td>100000x2000 (193M)<td>1000 <td> ~30 min : 75 machines
+<tr><td>Medium<td>NT (Fixed 565MB)<td>30000x2000 (58M)<td>100 <td> ~20 min : 20 machines
+<tr><td>Large<td>NT (Fixed 565MB)<td>100000x2000 (193M)<td>1000 <td> ~30 min : 75 machines
 </table>
 

--- a/bwa/README.md
+++ b/bwa/README.md
@@ -42,8 +42,8 @@ makeflow -T wq bwa.mf
 <tr><td>Workflow Size<td>Reference Size(Number x Length)<td>Query Size(Number x Length)<td>Number of seq per split<td> Approx Time with Machine
 <tr><td>Small<td>10000x1000 (Fixed 20M)<td>1000x100 (237K)<td>100 <td> ~10 sec : 1 machine
 <tr><td>Medium<td>100000x1000 (Fixed 196M)<td>10000x1000 (20M)<td>1000 <td> ~2 min : 20 machines
-<tr><td>Medium<td><td>100000x1000 (Fixed 196M)<td>1000000x100 (237M)<td>1000 <td> ~6 min : 20 machines
-<tr><td>Large<td><td>1000000x1000 (Fixed 2.0G)<td>1000000x100 (237M)<td>1000 <td> ~30 min : 20 machines
+<tr><td>Medium<td>100000x1000 (Fixed 196M)<td>1000000x100 (237M)<td>1000 <td> ~6 min : 20 machines
+<tr><td>Large<td>1000000x1000 (Fixed 2.0G)<td>1000000x100 (237M)<td>1000 <td> ~30 min : 20 machines
 </table>
 
 

--- a/bwa/README.md
+++ b/bwa/README.md
@@ -54,3 +54,5 @@ Workflow ~6 mins on 20 workers:
 ./make_bwa_workflow --ref ref.fastq --query query.fastq --num_seq 1000 --algo backtrack > bwa.mf
 ```
 
+Note: when using generated data we did not use the paired-end functionality of BWA
+as we do not guarantee both query and rquery are matched as a pair would be in real data.

--- a/bwa/README.md
+++ b/bwa/README.md
@@ -38,21 +38,14 @@ makeflow -T sge bwa.mf
 makeflow -T wq bwa.mf
 ```
 
-Workflow ~2 mins on 20 workers:
+<table cellpadding=20>
+<tr><td>Workflow Size<td>Reference Size(Number x Length)<td>Query Size(Number x Length)<td>Number of seq per split<td> Approx Time with Machine
+<tr><td>Small<td>10000x1000 (Fixed 20M)<td>1000x100 (237K)<td>100 <td> ~10 sec : 1 machine
+<tr><td>Medium<td>100000x1000 (Fixed 196M)<td>10000x1000 (20M)<td>1000 <td> ~2 min : 20 machines
+<tr><td>Medium<td><td>100000x1000 (Fixed 196M)<td>1000000x100 (237M)<td>1000 <td> ~6 min : 20 machines
+<tr><td>Large<td><td>1000000x1000 (Fixed 2.0G)<td>1000000x100 (237M)<td>1000 <td> ~30 min : 20 machines
+</table>
 
-```
-./fastq_generate.pl 100000 1000 > ref.fastq
-./fastq_generate.pl 10000 1000 ref.fastq > query.fastq
-./make_bwa_workflow --ref ref.fastq --query query.fastq --num_seq 1000 > bwa.mf
-```
-
-Workflow ~6 mins on 20 workers:
-
-```
-./fastq_generate.pl 100000 1000 > ref.fastq
-./fastq_generate.pl 1000000 100 ref.fastq > query.fastq
-./make_bwa_workflow --ref ref.fastq --query query.fastq --num_seq 1000 --algo backtrack > bwa.mf
-```
 
 Note: when using generated data we did not use the paired-end functionality of BWA
 as we do not guarantee both query and rquery are matched as a pair would be in real data.

--- a/ssaha/README.md
+++ b/ssaha/README.md
@@ -49,8 +49,8 @@ makeflow -T wq.ssaha.mf
 <table cellpadding=20>
 <tr><td>Workflow Size<td>Reference Size(Number x Length)<td>Query Size(Number x Length)<td>Number of seq per split<td> Approx Time with Machine
 <tr><td>Small<td>10000x2000 (Fixed 20M)<td>100000x100 (237K)<td>100 <td> ~5 min : 1 machine
-<tr><td>Medium<td><td>10000x2000 (Fixed 1000M)<td>1000000x100 (237M)<td>1000 <td> ~3 : 20 machines
-<tr><td>Large<td><td>100000x2000 (Fixed 4.0G)<td>1000000x500 (386M)<td>1000 <td> ~15 min : 20 machines
+<tr><td>Medium<td>10000x2000 (Fixed 1000M)<td>1000000x100 (237M)<td>1000 <td> ~3 : 20 machines
+<tr><td>Large<td>100000x2000 (Fixed 4.0G)<td>1000000x500 (386M)<td>1000 <td> ~15 min : 20 machines
 </table>
 
 

--- a/ssaha/README.md
+++ b/ssaha/README.md
@@ -46,17 +46,11 @@ makeflow -T sge ssaha.mf
 makeflow -T wq.ssaha.mf
 ```
 
-This should create a workload that runs in ~50 minutes on a single core machine or ~3 minutes on 20 workers
-```
-./fastq_generate.pl 10000 2000 > db.fastq
-./fastq_generate.pl 1000000 100 db.fastq > query.fastq
-./make_ssaha_workflow db.fastq query.fastq output.fastq 1000 > ssaha.mf
-```
+<table cellpadding=20>
+<tr><td>Workflow Size<td>Reference Size(Number x Length)<td>Query Size(Number x Length)<td>Number of seq per split<td> Approx Time with Machine
+<tr><td>Small<td>10000x2000 (Fixed 20M)<td>100000x100 (237K)<td>100 <td> ~5 min : 1 machine
+<tr><td>Medium<td><td>10000x2000 (Fixed 1000M)<td>1000000x100 (237M)<td>1000 <td> ~3 : 20 machines
+<tr><td>Large<td><td>100000x2000 (Fixed 4.0G)<td>1000000x500 (386M)<td>1000 <td> ~15 min : 20 machines
+</table>
 
-This should create a workload that runs in ~5 hours on a single core machine or ~15 minutes on 20 workers
-```
-./fastq_generate.pl 100000 2000  > db.fastq
-./fastq_generate.pl 1000000 500 db.fastq > query.fastq
-./make_ssaha_workflow db.fastq query.fastq output.fastq 1000 > ssaha.mf
-```
 


### PR DESCRIPTION
Removed space that caused issue with BWA backtrack. Added smaller examples. BWA was having issues if the reference was to large. I can add longer tests, it just requires larger query files.