### PR TITLE
FTP and Python

### DIFF
--- a/blast/README.md
+++ b/blast/README.md
@@ -15,7 +15,7 @@ cd ./makeflow-examples/blast
 
 First, obtain a blast binary suitable for your architecture. (about 30MB)
 ```
-wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.26/blast-2.2.26-x64-linux.tar.gz
+wget https://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.26/blast-2.2.26-x64-linux.tar.gz
 tar xvzf blast-2.2.26-x64-linux.tar.gz
 ```
 
@@ -24,9 +24,9 @@ Next, copy the main executable into the working directory.
 cp blast-2.2.26/bin/blastall .
 ```
 
-Obtain a nucleotide database suitable for searching. (about 400MB)
+Obtain a nucleotide database suitable for searching. (about 1.5GB)
 ```
-wget ftp://ftp.ncbi.nlm.nih.gov/blast/db/nt.44.tar.gz
+wget https://ftp.ncbi.nlm.nih.gov/blast/db/nt.044.tar.gz
 mkdir nt
 tar -C nt -xvzf nt.44.tar.gz
 ```
@@ -42,8 +42,8 @@ If everything is working correctly, you should see output that starts like this:
 ```
 BLASTN 2.2.26 [Sep-21-2011]
 
-Reference: Altschul, Stephen F., Thomas L. Madden, Alejandro A. Schaffer, 
-Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997), 
+Reference: Altschul, Stephen F., Thomas L. Madden, Alejandro A. Schaffer,
+Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997),
 "Gapped BLAST and PSI-BLAST: a new generation of protein database search
 programs",  Nucleic Acids Res. 25:3389-3402.
 
@@ -94,7 +94,7 @@ makeflow --jx blast.jx
 makeflow --json blast.json
 ```
 
-The number and length of sequences can be adjusted for your needs, with the first number 
+The number and length of sequences can be adjusted for your needs, with the first number
 adjusting the number of contigs and the second adjusting the length of these contigs.
 `fasta_generator` produces contigs containing random AGCT sequences.
 

--- a/blast/makeflow_blast
+++ b/blast/makeflow_blast
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # CCTOOLS_PYTHON_VERSION 2.7 2.6
 
 # Copyright (C) 2011- The University of Notre Dame

--- a/bwa/make_bwa_workflow
+++ b/bwa/make_bwa_workflow
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # CCTOOLS_PYTHON_VERSION 2.7 2.6
 #
 #Copyright (C) 2013- The University of Notre Dame

--- a/ssaha/README.md
+++ b/ssaha/README.md
@@ -4,7 +4,7 @@ SSAHA Workflow Example
 ----------------------
 
 This example workflow demonstrates how to parallelize the
-SSAHA2 (Sequence Search and Alignment by Hasing Algorithm)
+SSAHA2 (Sequence Search and Alignment by Hashing Algorithm)
 tool published by the Sanger institute.
 
 If you have not done so already, please clone this example repository like so:
@@ -17,7 +17,7 @@ First, download and install a suitable binary for SSAHA2:
 
 ```
 export SSAHA_BINARY=ssaha2_v2.5.5_x86_64
-wget ftp://ftp.sanger.ac.uk/pub/resources/software/ssaha2/${SSAHA_BINARY}.tgz
+wget https://ftp.sanger.ac.uk/pub/resources/software/ssaha2/${SSAHA_BINARY}.tgz 
 tar xvzf ${SSAHA_BINARY}.tgz
 cp ${SSAHA_BINARY}/ssaha2 .
 ```


### PR DESCRIPTION
Hi!
I was using the makeflow examples and found some small issues:
- FTP is not available on Wget2, but Wget1 and Wget2 both support HTTPS
- `nt.44` is now `nt.044` and it is bigger in size (I don't know if they are literally identical)
- Python 3 is not able to execute `make_xyz_workflow` commands, I replaced with `python2` in the ones I used, but I don't know if this is how it _should_ be handled
- I also had issues with the `small.fasta` in the `blast` example, but I am not sure if that was due to something I did